### PR TITLE
 Upstream changes and bug fixes on git

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,7 @@
         "**/*.egg-info": true,
     },
     "git.autofetch": true,
-    "python.pythonPath": "/mnt/hdd/development/venv/kaamiki/bin/python",
+    "python.pythonPath": "/mnt/hdd/development/universe/venv/bin/python",
     "python.linting.pylintEnabled": false,
     "python.linting.pycodestyleEnabled": true,
     "python.linting.enabled": true,


### PR DESCRIPTION
Aug 23, 2020 - v1.0.1

Added:
- ModulePath class for resolving record path name.
- Example for using SilenceOfTheLogs.

Changes:
- formatException is now a staticmethod.
- Logger format now mimics springboot style log output minus the colors.
- Module name length size is increased from 25 to 30 characters.
- Help comment for module name length.
- Virtualenv path for VScode.

Fixed:
- <module> bug when logging function name in script without function.
- Incorrect type hint for exc_info argument.