### PR TITLE
Add support for multiple FileHandlers

### DIFF
--- a/kaamiki/utils/logging.py
+++ b/kaamiki/utils/logging.py
@@ -17,23 +17,24 @@
 #     xames3 <44119552+xames3@users.noreply.github.com>
 
 """
-Logging Kaamiki
+Kaamiki Logger
 
-A Python based utility for logging all Kaamiki events.
+A Python based utility for logging Kaamiki events.
 """
 
+import datetime
 import logging
 import os
 import os.path as _os
 import sys
 from distutils.sysconfig import get_python_lib
+from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
 from pathlib import Path
 from typing import Union
 
 from kaamiki import USER, Neo, SysExcInfoType, replace_chars
 
 __all__ = ["Logger"]
-
 
 # NOTE: Most of the docstring content is referenced from the original
 # logging module as we're not changing the behaviour of any of its
@@ -162,24 +163,57 @@ class Logger(object):
   Logger class for logging all active instances of Kaamiki.
 
   The class captures all logged Kaamiki events and logs them silently.
-  Logger is packed with a convenient file handler along with formatter
-  which enables it to sequentially archive and record clean logs.
+  Logger is packed with a convenient file handlers along with formatter
+  which enables it to sequentially archive, record and clean logs.
 
   Logger provides flexible logging using the different arguments that
-  are provided to it. If none is supplied, default paths and logging
-  format is used. For the log format, Logger prefers the default one
-  as it seems to provide all the necessary details out of the box.
+  are provided to it. If none is supplied, default set of settings are
+  used. For the log format, Logger prefers the default one as it seems
+  to provide all the bells and whistles right off the bat.
   However, as described above the behaviour can be changed using the
   argument(s). In this case, `datefmt` and `fmt`.
 
-  Logger provides an option to colorize logging levels. By default, it
-  is True, you can switch the behaviour using `colored` argument.
+  Like any standard logger, Logger allows you to set your minimum
+  logging level using `level` argument. By default, the path and
+  the name of the log file is picked automatically by the Logger. The
+  same can be overridden by changing the `path` and the `name` arguments
+  respectively. Argument `root` is well, root logging point of the
+  logger. Logger provides an option to colorize logging levels. By
+  default, it is True, you can switch the behaviour using `colored`
+  argument. 
+
+  As stated above, Logger supports three primary file handlers - normal
+  FileHandler, RotatingFileHandler and TimedRotatingFileHandler.
+  Handlers are tools which allows logging to a set of files, which
+  switches from one file to the next either when the current file
+  reaches a certain size or reaches certain timed intervals, this is
+  called as `Rollover` or `Rotation`.
+  You can choose if the log file should rotate (rollover) or not using
+  the `rotate` flag. If set to True, you can specify the type of log
+  rotation i.e rotation based on log file size or rotation based on the
+  certain time frame by updating the `rotate_by` argument.
+
+  When `rotate_by` is set to "size", `Rollover` occurs whenever the
+  current log file is nearly `maxBytes` in length. If `maxBytes` is
+  zero, rollover never occurs. If backupCount is >= 1, the system will
+  successively create new files with extensions ".1", ".2" etc.
+  appended to it. For example, with a backupCount of 5 and a base file
+  name of "kaamiki.log", you would get "kaamiki.log", "kaamiki.log.1",
+  "kaamiki.log.2", ... through to "kaamiki.log.5". The file being
+  written to is always "kaamiki.log" - when it gets filled up, it is
+  closed and renamed to "kaamiki.log.1", and if files "kaamiki.log.1",
+  "kaamiki.log.2" etc. exist, then they are renamed to "kaamiki.log.2",
+  "kaamiki.log.3" etc. respectively.
+
+  When `rotate_by` is set to "time" log rotation occurs at certain time
+  intervals. If backupCount is > 0, when rollover is done, no more than
+  backupCount files are kept - the oldest ones are deleted.
 
   Example:
     >>> from kaamiki.utils.logging import Logger
     >>> log = Logger().log
     >>>
-    >>> log.info("This is how you use the Logger class.")
+    >>> log.info("This is how you use the Logger class with defaults.")
   """
 
   def __init__(self,
@@ -190,12 +224,22 @@ class Logger(object):
                path: str = None,
                root: str = None,
                colored: bool = True,
-               extra: dict = {}) -> None:
+               extra: dict = {},
+               rotate: bool = True,
+               rotate_by: str = "size",
+               maxBytes: int = 1000000, # Rotate when logs reach 1 MB
+               when: str = "h",
+               interval: int = 1,
+               utc: bool = False,
+               atTime: datetime.datetime = None,
+               backupCount: int = 5,
+               encoding: str = None,
+               delay: bool = False) -> None:
     """
     Initialize logger.
 
     Initialize the logger either with non-default values or with
-    default settings. Default args are configured to work direct
+    default settings. Default args are configured to work directly
     with Kaamiki, although the behaviour can be easily overridden.
     """
     self.fmt = fmt
@@ -207,6 +251,16 @@ class Logger(object):
     self.formatter = _Formatter(self.datefmt, self.fmt)
     self.stream = _StreamHandler() if self.colored else logging.StreamHandler()
     self.stream.setFormatter(self.formatter)
+    self.rotate = rotate
+    self.rotate_by = rotate_by
+    self.maxBytes = maxBytes
+    self.when = when
+    self.interval = interval
+    self.utc = utc
+    self.atTime = atTime
+    self.backupCount = backupCount
+    self.encoding = encoding
+    self.delay = delay
     try:
       self.py = _os.abspath(sys.modules["__main__"].__file__)
     except AttributeError:
@@ -216,7 +270,21 @@ class Logger(object):
     if not _os.exists(self.path):
       os.makedirs(self.path)
     self._file = _os.join(self.path, "".join([self.name, ".log"]))
-    self.file = logging.FileHandler(self._file)
+    if self.rotate:
+      if self.rotate_by == "time":
+        self.file = TimedRotatingFileHandler(
+            self._file, self.when, self.interval, self.backupCount,
+            self.encoding, self.delay, self.utc, self.atTime)
+      else:
+        # If rotation or rollover is wanted, it makes no sense to use
+        # another mode than `a`. Hence, the `mode` argument is not
+        # configurable.
+        self.file = RotatingFileHandler(
+            self._file, "a", self.maxBytes, self.backupCount, self.encoding,
+            self.delay)
+    else:
+      self.file = logging.FileHandler(
+          self._file, "a", self.encoding, self.delay)
     self.file.setFormatter(self.formatter)
     self.logger = logging.getLogger(self.root if self.root else None)
     self.logger.setLevel(self.level)
@@ -225,8 +293,8 @@ class Logger(object):
 
   def __repr__(self) -> str:
     """Return string representation of Kaamiki's logger object."""
-    name = f"Kaamiki{self.__class__.__name__}"
-    return (f"<{name}: {self.logger.name} - [{self.level}] - {self._file}>")
+    return (f"<KaamikiLogger: {self.logger.name} "
+            f"- [{self.level}] - {self._file}>")
 
   @property
   def log(self) -> logging.LoggerAdapter:


### PR DESCRIPTION
_Oct 24, 2020 - v0.0.1_

**Added:**
- Support for multiple **FileHandlers** for enabling log rotation.
- Elaborate doc string for the `Logger` class, thus explaining the
  usage of main arguments.

**Changed:**
- Logger repr now uses `KaamikiLogger` instead of using class name.
- Logger doc string and its example.
- Minor code refactor.