### PR TITLE
Major changes upstream to git

### DIFF
--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -19,17 +19,35 @@
 """
 Kaamiki
 
-A Python implementation of Kaamiki.
+A Python based implementation of Kaamiki.
+
+Kaamiki is a simple machine learning framework for obvious tasks. It is
+an operating system agnostic AI* developing package which aims at
+providing high-level and flexible python abstractions for running simple
+machine learning codes with great ease. Kaamiki also offers a couple of
+simple python based nifty tools (logger, file handlers, etc.) which
+could rather provide an extension to the developers existing work.
 """
 
 import getpass
+import json
 import re
 import string
+import urllib.error
+import urllib.request
+from distutils.version import StrictVersion
 from threading import Lock
 from types import TracebackType
 from typing import Tuple
 
-SysExcInfoType = Tuple[type, BaseException, TracebackType]
+from pkg_resources import parse_version
+
+__name__ = "kaamiki"
+__version__ = "0.0.1"
+__author__ = "Kaamiki Development Team"
+
+SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
+PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
 
 
 def replace_chars(text: str, sub: str = "_") -> str:
@@ -38,16 +56,18 @@ def replace_chars(text: str, sub: str = "_") -> str:
   return re.sub(r"[" + re.escape(string.punctuation) + "]", sub, text).lower()
 
 
+SESSION_USER = replace_chars(getpass.getuser())
+
+
 class Neo(type):
   """
   An implementation of thread-safe Singleton design pattern.
 
-  Singleton is a creational design pattern, which ensures that
-  only a single object of its kind exist and provides a single
-  point of access to it for any other code.
-  The below is a thread-safe implementation of the Singleton
-  design pattern. You can instantiate a class multiple times
-  and yet you would get reference to the same object.
+  Singleton is a creational design pattern, which ensures that only a
+  single object of its kind exist and provides a single point of access
+  to it for any other code. The below is a thread-safe implementation of
+  the Singleton design pattern. You can instantiate a class multiple
+  times and yet you would get reference to the same object.
 
   See https://stackoverflow.com/q/6760685 for more methods of
   implementing singletons in code.
@@ -55,15 +75,15 @@ class Neo(type):
   Example:
     >>> from kaamiki import Neo
     >>>
-    >>> class YourClass(metaclass=Neo):
+    >>> class DummyClass(metaclass=Neo):
     ...     pass
     ...
-    >>> singleton_obj1 = YourClass()
-    >>> singleton_obj2 = YourClass()
+    >>> singleton_obj1 = DummyClass()
+    >>> singleton_obj2 = DummyClass()
     >>> singleton_obj1
-    <__main__.YourClass object at 0x7fc8f1948970>
+    <__main__.DummyClass object at 0x7fc8f1948970>
     >>> singleton_obj2
-    <__main__.YourClass object at 0x7fc8f1948970>
+    <__main__.DummyClass object at 0x7fc8f1948970>
   """
   # For better understanding of the below implementation, read this:
   # https://refactoring.guru/design-patterns/singleton/python/example
@@ -71,11 +91,49 @@ class Neo(type):
   _lock = Lock()
 
   def __call__(cls, *args, **kwargs):
-    """Callable instance of neo class."""
+    """Callable instance of Neo."""
     with cls._lock:
       if cls not in cls._instances:
         cls._instances[cls] = super().__call__(*args, **kwargs)
     return cls._instances[cls]
 
 
-USER = replace_chars(getpass.getuser())
+def latest_version() -> str:
+  """Check for the latest stable version of Kaamiki on PyPI."""
+  try:
+    data = json.load(urllib.request.urlopen(PYPI_URL))["releases"].keys()
+    version = sorted(data, key=StrictVersion, reverse=True)[0]
+    return version if version else __version__
+  except urllib.error.URLError:
+    # Explicitly return a custom error string in case the network is not
+    # available while checking the state on PyPI.
+    return "NetworkConnectionError"
+
+
+def show_version() -> None:
+  """
+  Show version status of Kaamiki.
+
+  Show the installed version status of Kaamiki with respect to the
+  available builds. This function not only displays the installed build
+  but displays the upgrade or downgrade recommendations when checked.
+  """
+  latest = latest_version()
+  pkg = __name__.capitalize()
+
+  if latest != "NetworkConnectionError":
+    if parse_version(__version__) < parse_version(latest):
+      print(f"You are using an older version of {pkg}, v{__version__}\n"
+            f"However, v{latest} is currently available for download. You "
+            f"should consider upgrading to it using \"pip install --upgrade "
+            f"{__name__}\" command.")
+    elif parse_version(__version__) > parse_version(latest):
+      print(f"You are using a development version of {pkg}, v{__version__}\n"
+            f"If you want to roll back to a stable version, consider "
+            f"downgrading using \"pip install {__name__}\" command.")
+    else:
+      print(f"You are using the latest stable version of {pkg}, v{latest}")
+  else:
+    print(f"WARNING: Internet connection is questionable at the moment. "
+          f"Couldn't check for the latest stable version of {pkg}.\nInstalled "
+          f"version is v{__version__}")

--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -53,6 +53,8 @@ class Neo(type):
   implementing singletons in code.
 
   Example:
+    >>> from kaamiki import Neo
+    >>>
     >>> class YourClass(metaclass=Neo):
     ...     pass
     ...

--- a/kaamiki/parser.py
+++ b/kaamiki/parser.py
@@ -32,6 +32,8 @@ import sys
 from textwrap import TextWrapper as _wrapper
 from typing import Any, List, Tuple
 
+from kaamiki import __author__, __name__, show_version
+
 __all__ = ["main"]
 
 # NOTE: Do not import and use main() directly. Using it directly is
@@ -39,11 +41,11 @@ __all__ = ["main"]
 # change with time and modifications happening in the existing
 # implementation, so calling it directly is probably not a good idea.
 
+COPYRIGHT = f"Copyright (c) 2020 {__author__}. All rights reserved."
+EPILOG = (f"For specific information about a particular command, run "
+          f"\"{__name__} <command> -h\".")
 URL = "Read complete documentation at: https://github.com/kaamiki/kaamiki"
-COPYRIGHT = "Copyright (c) 2020 Kaamiki Development Team. All rights reserved."
-USAGE = "kaamiki <command> [options] ..."
-EPILOG = ("For specific information about a particular command, run "
-          "'kaamiki <command> -h'.")
+USAGE = f"{__name__} <command> [options] ..."
 
 
 class Parser(argparse.ArgumentParser):
@@ -66,7 +68,7 @@ class Parser(argparse.ArgumentParser):
   needed to parse the argument(s) to the callable instance from the
   command line.
 
-  It enables the usage of keyword, `kaamiki` to call instances of
+  It enables the usage of keyword, "kaamiki" to call instances of
   Kaamiki's methods.
 
   NOTE: The scope of this class is not to defy the behaviour of the
@@ -121,7 +123,7 @@ class Parser(argparse.ArgumentParser):
     This method defines the usage block and provides information along
     with the syntax of using a particular command.
 
-    NOTE: Not every command has usage information.
+    NOTE: Not every command has `usage` information.
     """
     prefix = "Usage:\n  "
     usage = []
@@ -302,14 +304,17 @@ def main() -> None:
   or function calls from Kaamiki suite using simple commands.
   """
   parser = Parser(usage=USAGE, epilog=EPILOG, conflict_handler="resolve")
-  parser.add_argument("-h", "--help", help="Show help.", action="store_true",
+  parser.add_argument("-h", "--help", action="store_true",
+                      help="Show this help message.",
                       default=argparse.SUPPRESS)
   parser.add_argument("-V", "--version", action="store_true",
-                      help="Show installed Kaamiki version and exit.",
+                      help="Show installed Kaamiki version.",
                       default=argparse.SUPPRESS)
   cmd_args = parser.parse_args()
+
   if hasattr(cmd_args, "function"):
     cmd_args.function(cmd_args)
+  elif hasattr(cmd_args, "version"):
+    show_version()
   else:
     parser.print_help()
-    sys.exit(0)

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -139,7 +139,7 @@ class _StreamHandler(logging.StreamHandler, metaclass=Neo):
   Note that this class does not close the stream, as sys.stdout
   or sys.stderr may be used.
   """
-  # TODO(xames3): Consider adding support to Windows systems.
+  # TODO(PranaliRPatil): Consider adding support to Windows systems.
   # See https://gist.github.com/mooware/a1ed40987b6cc9ab9c65
   # for implementation for a Windows machine.
 
@@ -210,10 +210,10 @@ class Logger(object):
   backup_count files are kept - the oldest ones are deleted.
 
   Example:
-    >>> from kaamiki.utils.logging import Logger
-    >>> log = Logger().log
+    >>> from kaamiki.utils.logger import Logger
+    >>> logger = Logger().log
     >>>
-    >>> log.info("This is how you use the Logger class with defaults.")
+    >>> logger.info("This is how you use the Logger class with defaults.")
   """
 
   def __init__(self,
@@ -227,7 +227,7 @@ class Logger(object):
                extra: dict = {},
                rotate: bool = True,
                rotate_by: str = "size",
-               max_bytes: int = 1000000, # Rotate when logs reach 1 MB
+               max_bytes: int = 1000000,  # Rotate when logs reach 1 MB
                when: str = "h",
                interval: int = 1,
                utc: bool = False,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ Kaamiki
 
 Kaamiki is a simple machine learning framework for obvious tasks.
 """
-# TODO(xames3): Add a descriptive docstring which would help the
+# TODO(xames3): Add a descriptive doc string which would help the
 # users and developers alike to get an idea what and how Kaamiki
 # could assist them right out of the box with minimal efforts.
 
@@ -33,31 +33,25 @@ import sys
 # for installing Kaamiki. See https://github.com/kaamiki/kaamiki
 # for more help.
 if sys.version_info < (3, ):
-  sys.exit("Python 2 has officially reached end-of-life "
-           "and is no longer supported by Kaamiki.")
+  sys.exit("Python 2 has officially reached end-of-life and is no longer "
+           "supported by Kaamiki.")
 
 if sys.version_info < (3, 6, 9):
-  sys.exit("Kaamiki supports minimum python 3.6.9 and above. Kindly "
-           "upgrade your python interpreter to a suitable version.")
+  sys.exit("Kaamiki supports minimum python 3.6.9 and above. Kindly upgrade "
+           "your python interpreter to a suitable version.")
 
 if os.name == "nt" and sys.maxsize.bit_length() == 31:
-  sys.exit("32-bit Python runtime is not supported. Please switch to "
-           "64-bit Python.")
+  sys.exit("32-bit Python runtime is not supported. Please switch to 64-bit "
+           "Python.")
 
 from setuptools import find_packages, setup
 
-_NAME = "kaamiki"
+from kaamiki import __author__, __name__, __version__
 
-# The version string is semver compatible and adheres to Semantic
-# Versioning Specification (SemVer) starting with the version 0.1.
-# See https://semver.org/spec/v2.0.0.html for more help.
-_VERSION = "0.0.1"
-
-# Flag which raises warning if the installed version of Kaamiki
-# is either outdated or a nightly (development) build.
-_STATUS_FLAG = 0
-
-_DESCRIPTION = __doc__.splitlines()[3]
+# Flag which raises warning if the installed version of Kaamiki is
+# either outdated or a nightly (development) build.
+STATUS_FLAG = 0
+DESCRIPTION = __doc__.splitlines()[3]
 
 with open("requirements.txt", "r") as requirements:
   if os.name == "nt":
@@ -67,43 +61,42 @@ with open("requirements.txt", "r") as requirements:
     packages = [idx for idx in requirements if idx.rstrip() not in skip]
 
 
-def _parse_readme() -> str:
+def parse_readme() -> str:
   """Parse README.md for long description of Kaamiki."""
   with open("README.md", "r") as file:
     return file.read()
 
 
-def _prepare() -> None:
+def prepare() -> None:
   """Prepare the required directory structure while setting up."""
   # Create base directory for caching, logging and storing data for/of
   # a Kaamiki session.
-  base = _os.expanduser(f"~/.{_NAME}/")
+  base = _os.expanduser(f"~/.{__name__}/")
   if not _os.exists(base):
     os.mkdir(base)
   with open(os.path.join(base, "update"), "w") as file:
-    file.write(f"name: {_NAME}\n"
-               f"version: {_VERSION}\n"
-               f"status: {_STATUS_FLAG}")
+    file.write(f"name: {__name__}\n"
+               f"version: {__version__}\n"
+               f"status: {STATUS_FLAG}")
 
 
 setup(
-    name=_NAME,
-    version=_VERSION,
-    url="https://github.com/kaamiki/kaamiki",
-    author="Kaamiki Development Team",
+    name=__name__,
+    version=__version__,
+    author=__author__,
     author_email="xames3.kaamiki@gmail.com",
     maintainer_email="xames3.kaamiki@gmail.com",
+    url="https://github.com/kaamiki/kaamiki",
     license="Apache Software License 2.0",
-    description=" ".join(_DESCRIPTION[3:5]),
-    long_description=_parse_readme(),
+    description=DESCRIPTION,
+    long_description=parse_readme(),
     long_description_content_type="text/markdown",
-    keywords="kaamiki python cv2",
+    keywords="kaamiki python",
     zip_safe=False,
     install_requires=packages,
     python_requires=">=3.6.9",
     include_package_data=True,
     packages=find_packages(),
-    platform=["Linux", "Windows", "macOS"],
     entry_points={
         "console_scripts": [
             "kaamiki = kaamiki.parser:main",
@@ -131,4 +124,4 @@ setup(
 )
 
 if __name__ == "__main__":
-  _prepare()
+  prepare()


### PR DESCRIPTION
_Nov 01, 2020 - v0.0.1_

**Added:**
- Support for colored logging levels on Windows platform.
- Support for checking installed version of Kaamiki using parser.
- Doc string for Kaamiki.

**Changed:**
- Output logging level colors.
- Entry point help and version messages while using parser.
- Package name, author and version details are now moved to Kaamiki. The
  variables now are dynamically used throughout the module.
- Inline comments to fit the current development status and minor
  message tone.
- `Access modifier` state* of some methods are now made public to respect
  Python's dynamic behavior.
- Constants now adheres uppercase naming convention.
- Doc string example and doc strings for classes.