### PR TITLE
Move SYS_EXC_INFO_TYPE to logger module

### DIFF
--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -37,8 +37,6 @@ import urllib.error
 import urllib.request
 from distutils.version import StrictVersion
 from threading import Lock
-from types import TracebackType
-from typing import Tuple
 
 from pkg_resources import parse_version
 
@@ -46,7 +44,6 @@ __name__ = "kaamiki"
 __version__ = "0.0.1"
 __author__ = "Kaamiki Development Team"
 
-SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
 
 

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -31,10 +31,10 @@ import sys
 from distutils.sysconfig import get_python_lib
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
 from pathlib import Path
-from typing import Union
+from types import TracebackType
+from typing import Tuple, Union
 
-from kaamiki import (SESSION_USER, SYS_EXC_INFO_TYPE, Neo, __name__,
-                     replace_chars)
+from kaamiki import SESSION_USER, Neo, __name__, replace_chars
 
 __all__ = ["Logger"]
 
@@ -52,6 +52,7 @@ BLUE = "\u001b[38;5;39m"
 CYAN = "\u001b[38;5;14m"
 ORANGE = "\u001b[38;5;208m"
 
+SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 DEFAULT_LOG_PATH = _os.expanduser(f"~/.{__name__}/{SESSION_USER}/logs/")
 
 _colors = {


### PR DESCRIPTION
_Nov 02, 2020 - v0.0.1_

**Changed:**
- Moved SYS_EXC_INFO_TYPE variable to logger module as it
  is not being used anywhere else in the project hence a global
  declaration is not needed.