### PR TITLE
Remove log method from Logger class

### DIFF
--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -37,8 +37,6 @@ import urllib.error
 import urllib.request
 from distutils.version import StrictVersion
 from threading import Lock
-from types import TracebackType
-from typing import Tuple
 
 from pkg_resources import parse_version
 
@@ -46,7 +44,6 @@ __name__ = "kaamiki"
 __version__ = "0.0.1"
 __author__ = "Kaamiki Development Team"
 
-SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
 
 

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -31,10 +31,10 @@ import sys
 from distutils.sysconfig import get_python_lib
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
 from pathlib import Path
-from typing import Union
+from types import TracebackType
+from typing import Tuple, Union
 
-from kaamiki import (SESSION_USER, SYS_EXC_INFO_TYPE, Neo, __name__,
-                     replace_chars)
+from kaamiki import SESSION_USER, Neo, __name__, replace_chars
 
 __all__ = ["Logger"]
 
@@ -52,6 +52,7 @@ BLUE = "\u001b[38;5;39m"
 CYAN = "\u001b[38;5;14m"
 ORANGE = "\u001b[38;5;208m"
 
+SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 DEFAULT_LOG_PATH = _os.expanduser(f"~/.{__name__}/{SESSION_USER}/logs/")
 
 _colors = {

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -167,7 +167,7 @@ class _StreamHandler(logging.StreamHandler, metaclass=Neo):
     return log.replace(record.levelname, colored)
 
 
-class Logger(object):
+class Logger(logging.LoggerAdapter):
   """
   Logger class for logging all active instances of Kaamiki.
 
@@ -220,7 +220,7 @@ class Logger(object):
 
   Example:
     >>> from kaamiki.utils.logger import Logger
-    >>> logger = Logger().log
+    >>> logger = Logger()
     >>>
     >>> logger.info("This is how you use the Logger class")
   """
@@ -273,12 +273,12 @@ class Logger(object):
     try:
       self.py = _os.abspath(sys.modules["__main__"].__file__)
     except AttributeError:
-      self.py = "terminal.py"
-    self.name = replace_chars(name if name else Path(self.py).stem)
+      self.py = "console.py"
+    self._name = replace_chars(name if name else Path(self.py).stem)
     self.path = path if path else DEFAULT_LOG_PATH
     if not _os.exists(self.path):
       os.makedirs(self.path)
-    self._file = _os.join(self.path, "".join([self.name, ".log"]))
+    self._file = _os.join(self.path, "".join([self._name, ".log"]))
     if self.rotate:
       if self.rotate_by == "time":
         self.file = TimedRotatingFileHandler(
@@ -302,10 +302,4 @@ class Logger(object):
 
   def __repr__(self) -> str:
     """Return string representation of Kaamiki's logger object."""
-    return (f"<KaamikiLogger: {self.logger.name} "
-            f"- [{self.level}] - {self._file}>")
-
-  @property
-  def log(self) -> logging.LoggerAdapter:
-    """Return an adapter to log events."""
-    return logging.LoggerAdapter(self.logger, extra=self.extra)
+    return f"KaamikiLogger(name={self.root!r}, level={self.level!r})"


### PR DESCRIPTION
_Nov 03, 2020 - v0.0.1_

**Changed:**
- Logger class no longer needs the log method to call log level methods.
- \_\_rep\_\_ now returns more realistic representation of Logger class.
- Shell logging file, `terminal.py` is now called `console.py`.
- Logger example in doc string with new change.

**Removed:**
- log method.