### PR TITLE
Adopt pathlib over os.path and critical changes

### DIFF
--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -36,6 +36,7 @@ import string
 import urllib.error
 import urllib.request
 from distutils.version import StrictVersion
+from pathlib import Path
 from threading import Lock
 
 from pkg_resources import parse_version
@@ -44,16 +45,9 @@ __name__ = "kaamiki"
 __version__ = "0.0.1"
 __author__ = "Kaamiki Development Team"
 
-PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
+__all__ = ["BASE_DIR", "SESSION_USER", "Neo", "replace_chars", "show_version"]
 
-
-def replace_chars(text: str, sub: str = "_") -> str:
-  """Replace special characters with substitution string."""
-  # See https://stackoverflow.com/a/23996414/14316408 for more help.
-  return re.sub(r"[" + re.escape(string.punctuation) + "]", sub, text).lower()
-
-
-SESSION_USER = replace_chars(getpass.getuser())
+BASE_DIR = Path().home() / f".{__name__}"
 
 
 class Neo(type):
@@ -95,9 +89,16 @@ class Neo(type):
     return cls._instances[cls]
 
 
+def replace_chars(text: str, sub: str = "_") -> str:
+  """Replace special characters with substitution string."""
+  # See https://stackoverflow.com/a/23996414/14316408 for more help.
+  return re.sub(r"[" + re.escape(string.punctuation) + "]", sub, text).lower()
+
+
 def latest_version() -> str:
   """Check for the latest stable version of Kaamiki on PyPI."""
   try:
+    PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
     data = json.load(urllib.request.urlopen(PYPI_URL))["releases"].keys()
     version = sorted(data, key=StrictVersion, reverse=True)[0]
     return version if version else __version__
@@ -134,3 +135,6 @@ def show_version() -> None:
     print(f"WARNING: Internet connection is questionable at the moment. "
           f"Couldn't check for the latest stable version of {pkg}.\nInstalled "
           f"version is v{__version__}")
+
+
+SESSION_USER = replace_chars(getpass.getuser())

--- a/kaamiki/__init__.py
+++ b/kaamiki/__init__.py
@@ -37,8 +37,6 @@ import urllib.error
 import urllib.request
 from distutils.version import StrictVersion
 from threading import Lock
-from types import TracebackType
-from typing import Tuple
 
 from pkg_resources import parse_version
 
@@ -46,7 +44,6 @@ __name__ = "kaamiki"
 __version__ = "0.0.1"
 __author__ = "Kaamiki Development Team"
 
-SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 PYPI_URL = f"https://pypi.org/pypi/{__name__}/json"
 
 

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -31,10 +31,10 @@ import sys
 from distutils.sysconfig import get_python_lib
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
 from pathlib import Path
-from typing import Union
+from types import TracebackType
+from typing import Tuple, Union
 
-from kaamiki import (SESSION_USER, SYS_EXC_INFO_TYPE, Neo, __name__,
-                     replace_chars)
+from kaamiki import SESSION_USER, Neo, __name__, replace_chars
 
 __all__ = ["Logger"]
 
@@ -52,6 +52,7 @@ BLUE = "\u001b[38;5;39m"
 CYAN = "\u001b[38;5;14m"
 ORANGE = "\u001b[38;5;208m"
 
+SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
 DEFAULT_LOG_PATH = _os.expanduser(f"~/.{__name__}/{SESSION_USER}/logs/")
 
 _colors = {

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -167,7 +167,7 @@ class _StreamHandler(logging.StreamHandler, metaclass=Neo):
     return log.replace(record.levelname, colored)
 
 
-class Logger(object):
+class Logger(logging.LoggerAdapter):
   """
   Logger class for logging all active instances of Kaamiki.
 
@@ -220,7 +220,7 @@ class Logger(object):
 
   Example:
     >>> from kaamiki.utils.logger import Logger
-    >>> logger = Logger().log
+    >>> logger = Logger()
     >>>
     >>> logger.info("This is how you use the Logger class")
   """
@@ -273,12 +273,12 @@ class Logger(object):
     try:
       self.py = _os.abspath(sys.modules["__main__"].__file__)
     except AttributeError:
-      self.py = "terminal.py"
-    self.name = replace_chars(name if name else Path(self.py).stem)
+      self.py = "console.py"
+    self._name = replace_chars(name if name else Path(self.py).stem)
     self.path = path if path else DEFAULT_LOG_PATH
     if not _os.exists(self.path):
       os.makedirs(self.path)
-    self._file = _os.join(self.path, "".join([self.name, ".log"]))
+    self._file = _os.join(self.path, "".join([self._name, ".log"]))
     if self.rotate:
       if self.rotate_by == "time":
         self.file = TimedRotatingFileHandler(
@@ -302,10 +302,4 @@ class Logger(object):
 
   def __repr__(self) -> str:
     """Return string representation of Kaamiki's logger object."""
-    return (f"<KaamikiLogger: {self.logger.name} "
-            f"- [{self.level}] - {self._file}>")
-
-  @property
-  def log(self) -> logging.LoggerAdapter:
-    """Return an adapter to log events."""
-    return logging.LoggerAdapter(self.logger, extra=self.extra)
+    return f"KaamikiLogger(name={self.root!r}, level={self.level!r})"

--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Tuple, Union
 
-from kaamiki import SESSION_USER, Neo, __name__, replace_chars
+from kaamiki import BASE_DIR, SESSION_USER, Neo, __name__, replace_chars
 
 __all__ = ["Logger"]
 
@@ -53,7 +53,11 @@ CYAN = "\u001b[38;5;14m"
 ORANGE = "\u001b[38;5;208m"
 
 SYS_EXC_INFO_TYPE = Tuple[type, BaseException, TracebackType]
-DEFAULT_LOG_PATH = _os.expanduser(f"~/.{__name__}/{SESSION_USER}/logs/")
+
+# NOTE: All log events are recorded in `DEFAULT_LOG_PATH` by default, if
+# not being overridden while instantiating. Kaamiki doesn't record error
+# logs seperately!
+DEFAULT_LOG_PATH = BASE_DIR / SESSION_USER / "logs/" 
 
 _colors = {
     logging.DEBUG: GRAY,
@@ -236,7 +240,7 @@ class Logger(logging.LoggerAdapter):
                extra: dict = {},
                rotate: bool = True,
                rotate_by: str = "size",
-               max_bytes: int = 1000000,  # Rotate when logs reach 1 MB
+               max_bytes: int = 1024000,  # Rotate when logs reach 1 MB
                when: str = "h",
                interval: int = 1,
                utc: bool = False,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ Kaamiki is a simple machine learning framework for obvious tasks.
 # could assist them right out of the box with minimal efforts.
 
 import os
-import os.path as _os
 import sys
 
 # Raise exceptions if the host system is not properly configured
@@ -46,19 +45,13 @@ if os.name == "nt" and sys.maxsize.bit_length() == 31:
 
 from setuptools import find_packages, setup
 
-from kaamiki import __author__, __name__, __version__
+from kaamiki import BASE_DIR, __author__, __name__, __version__
 
 # Flag which raises warning if the installed version of Kaamiki is
 # either outdated or a nightly (development) build.
-STATUS_FLAG = 0
-DESCRIPTION = __doc__.splitlines()[3]
+STATUS = 0
 
-with open("requirements.txt", "r") as requirements:
-  if os.name == "nt":
-    packages = [idx for idx in requirements]
-  else:
-    skip = ["pywin32", "pypywin32", "pywinauto"]
-    packages = [idx for idx in requirements if idx.rstrip() not in skip]
+DESCRIPTION = __doc__.splitlines()[3]
 
 
 def parse_readme() -> str:
@@ -67,18 +60,12 @@ def parse_readme() -> str:
     return file.read()
 
 
-def prepare() -> None:
-  """Prepare the required directory structure while setting up."""
-  # Create base directory for caching, logging and storing data for/of
-  # a Kaamiki session.
-  base = _os.expanduser(f"~/.{__name__}/")
-  if not _os.exists(base):
-    os.mkdir(base)
-  with open(os.path.join(base, "update"), "w") as file:
-    file.write(f"name: {__name__}\n"
-               f"version: {__version__}\n"
-               f"status: {STATUS_FLAG}")
-
+with open("requirements.txt", "r") as requirements:
+  if os.name == "nt":
+    packages = [idx for idx in requirements]
+  else:
+    skip = ["pywin32", "pypywin32", "pywinauto"]
+    packages = [idx for idx in requirements if idx.rstrip() not in skip]
 
 setup(
     name=__name__,
@@ -123,5 +110,12 @@ setup(
     ],
 )
 
-if __name__ == "__main__":
-  prepare()
+# Create base directory for caching, logging and storing data for/of
+# a Kaamiki session.
+if not BASE_DIR.exists():
+  os.mkdir(BASE_DIR)
+with open(BASE_DIR / "update", "w") as update:
+  # TODO(xames3): Check if the status is really necessary with the team.
+  update.write(f"name: {__name__}\n"
+               f"version: {__version__}\n"
+               f"status: {STATUS}")


### PR DESCRIPTION
_Nov 03, 2020 - v0.0.1_

**Changed:**
- Logger class no longer needs the log method to call log level methods.
- \_\_rep\_\_ now returns more realistic representation of Logger class.
- Shell logging file, `terminal.py` is now called `console.py`.
- Logger example in doc string with new change.

**Removed:**
- log method.

_Nov 04, 2020 - v0.0.1_

**Added:**
- Global support for `BASE_DIR` in Kaamiki.

**Changed:**
- All modules now adopt pathlib over os.path for paths.
- `STATUS_FLAG` is now `STATUS` in setup module.
- logger.Logger's `max_bytes` argument now defaults to 1 MB instead of
  1000 KBs.