### PR TITLE
Major refactor and add custom log methods

### DIFF
--- a/kaamiki/utils/logger.py
+++ b/kaamiki/utils/logger.py
@@ -31,7 +31,7 @@ from distutils.sysconfig import get_python_lib
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
 from pathlib import Path
 from types import TracebackType as _type
-from typing import Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from kaamiki import BASE_DIR, SESSION_USER, Neo, __name__, replace_chars
 from kaamiki.utils.exceptions import InvalidArgumentError
@@ -56,12 +56,23 @@ _DEFAULT_LOG_PATH = BASE_DIR / SESSION_USER / _LOGS_DIR
 _DEFAULT_DATE_FMT = "%b %d, %Y %H:%M:%S"
 _DEFAULT_LOG_FMT = ("%(asctime)s.%(msecs)03d %(levelname)8s "
                     "%(process)07d [{:>15}] {:>30}:%(lineno)04d : %(message)s")
-_DEFAULT_EXC_FMT = "{0}: {1} {2} on line {3}."
+_DEFAULT_EXC_FMT = "{0}: {1} {2}on line {3}."
 
 # Character limit for displaying the module name which is logging the
 # record. This value is useful only in case the logger in use uses the
 # default kaamiki logging format.
 _DEFAULT_MODULE_NAME_LIMIT = 30
+
+_LOG_LEVELS = [
+    "CRITICAL",
+    "FATAL",
+    "ERROR",
+    "WARNING",
+    "WARN",
+    "INFO",
+    "DEBUG",
+    "NOTSET",
+]
 
 RESET = "\u001b[39m"
 GRAY = "\u001b[38;5;244m"
@@ -73,11 +84,12 @@ CYAN = "\u001b[38;5;14m"
 ORANGE = "\u001b[38;5;208m"
 
 _colors = {
-    logging.DEBUG: GRAY,
-    logging.INFO: GREEN,
-    logging.WARNING: YELLOW,
-    logging.ERROR: ORANGE,
     logging.CRITICAL: RED,
+    logging.ERROR: ORANGE,
+    logging.WARNING: YELLOW,
+    logging.INFO: GREEN,
+    logging.DEBUG: GRAY,
+    logging.NOTSET: CYAN,
 }
 
 
@@ -99,7 +111,10 @@ class _Formatter(logging.Formatter, metaclass=Neo):
   are inspired from the `Spring Boot` framework.
   """
 
-  def __init__(self, date_fmt: str = None, fmt: str = None) -> None:
+  def __init__(self,
+               date_fmt: Optional[str] = None,
+               fmt: Optional[str] = None,
+               traceback: bool = False) -> None:
     """
     Initialize formatter.
 
@@ -115,6 +130,7 @@ class _Formatter(logging.Formatter, metaclass=Neo):
       fmt = _DEFAULT_LOG_FMT
     self.fmt = fmt
     self.exc_fmt = _DEFAULT_EXC_FMT
+    self.traceback = traceback
 
   def formatException(self, ei: Tuple[type, BaseException, _type]) -> str:
     """Format and return the specified exception info as a string."""
@@ -139,15 +155,16 @@ class _Formatter(logging.Formatter, metaclass=Neo):
                   bool(module[_DEFAULT_MODULE_NAME_LIMIT - 3:]) * "...")
       log = logging.Formatter(self.fmt.format(thd, module), self.date_fmt)
     log = log.format(record)
-    if record.exc_text:
-      func = record.funcName
-      func = f"in {func}() " if func != "<module>" else ""
-      exc_msg = self.exc_fmt.format(record.exc_info[1].__class__.__name__,
-                                    record.msg,
-                                    func,
-                                    record.exc_info[2].tb_lineno)
-      log = log.replace("\n", "").replace(str(record.exc_info[-2]), exc_msg)
-      log, _, _ = log.partition("Traceback")
+    if not self.traceback:
+      if record.exc_text:
+        func = record.funcName
+        func = f"in {func}() " if func != "<module>" else ""
+        exc_msg = self.exc_fmt.format(record.exc_info[1].__class__.__name__,
+                                      record.msg,
+                                      func,
+                                      record.exc_info[2].tb_lineno)
+        log = log.replace("\n", "").replace(str(record.exc_info[-2]), exc_msg)
+        log, _, _ = log.partition("Traceback")
     return log
 
 
@@ -245,25 +262,26 @@ class Logger(logging.LoggerAdapter):
   suffix = ".log"
 
   def __init__(self,
-               fmt: str = None,
-               date_fmt: str = None,
-               level: Union[int, str] = None,
-               name: str = None,
-               path: Union[Path, str] = None,
+               fmt: Optional[str] = None,
+               date_fmt: Optional[str] = None,
+               level: Optional[Union[int, str]] = None,
+               name: Optional[str] = None,
+               path: Optional[Union[Path, str]] = None,
                root: str = None,
-               colored: bool = True,
-               extra: dict = None,
-               rotate: bool = True,
+               colored: Optional[bool] = True,
+               traceback: bool = False,
+               extra: Optional[Dict[str, Any]] = None,
+               rotate: Optional[bool] = True,
                rotate_by: str = "size",
                max_bytes: int = 0,
                when: str = "h",
                interval: int = 1,
                utc: bool = False,
-               at_time: datetime.datetime = None,
+               at_time: Optional[datetime.datetime] = None,
                backups: int = 0,
-               encoding: str = None,
+               encoding: Optional[str] = None,
                delay: bool = False,
-               to_file: bool = True) -> None:
+               to_file: Optional[bool] = True) -> None:
     """
     Initialize logger.
 
@@ -273,13 +291,18 @@ class Logger(logging.LoggerAdapter):
     """
     self.fmt = fmt
     self.date_fmt = date_fmt
+    if not isinstance(level, (int, str)) and level is not None:
+      raise InvalidArgumentError(arg=level, valid=True)
+    if isinstance(level, str) and level not in _LOG_LEVELS:
+      raise ValueError(
+          f"{level!r} is not a valid logging level. "
+          f"Choose correct logging level from these available options: "
+          f"{', '.join(_LOG_LEVELS[:-2] + [' and '.join(_LOG_LEVELS[-2:])])}")
     self.level = logging.getLevelName(level if level else logging.DEBUG)
     self.root = root
     self.colored = colored
+    self.traceback = traceback
     self.extra = extra if extra else {}
-    self.formatter = _Formatter(self.date_fmt, self.fmt)
-    self.stream = _StreamHandler() if self.colored else logging.StreamHandler()
-    self.stream.setFormatter(self.formatter)
     self.rotate = rotate
     self.rotate_by = rotate_by
     self.max_bytes = max_bytes
@@ -291,6 +314,9 @@ class Logger(logging.LoggerAdapter):
     self.encoding = encoding
     self.delay = delay
     self.to_file = to_file
+    self.formatter = _Formatter(self.date_fmt, self.fmt, self.traceback)
+    self.stream = _StreamHandler() if self.colored else logging.StreamHandler()
+    self.stream.setFormatter(self.formatter)
     self.logger = logging.getLogger(self.root if self.root else None)
     self.logger.setLevel(self.level)
     try:
@@ -302,27 +328,59 @@ class Logger(logging.LoggerAdapter):
     if not Path(self.path).exists():
       os.makedirs(self.path)
     if self.to_file:
-      self._file = Path(self.path) / (self._name + self.suffix)
+      self.file_path = Path(self.path) / (self._name + self.suffix)
       if self.rotate:
         if self.rotate_by not in ("size", "time"):
           raise InvalidArgumentError(arg=self.rotate_by, valid=True)
         if self.rotate_by == "time":
           self.file = TimedRotatingFileHandler(
-              self._file, self.when, self.interval, self.backups,
+              self.file_path, self.when, self.interval, self.backups,
               self.encoding, self.delay, self.utc, self.at_time)
         else:
           # If rotation or rollover is wanted, it makes no sense to use
-          # another mode than `a`. Hence, the `mode` is not configurable.
+          # another mode than `a`. Hence, it is not configurable.
           self.file = RotatingFileHandler(
-              self._file, "a", self.max_bytes, self.backups, self.encoding,
+              self.file_path, "a", self.max_bytes, self.backups, self.encoding,
               self.delay)
       else:
         self.file = logging.FileHandler(
-            self._file, "a", self.encoding, self.delay)
+            self.file_path, "a", self.encoding, self.delay)
       self.file.setFormatter(self.formatter)
       self.logger.addHandler(self.file)
     self.logger.addHandler(self.stream)
 
   def __repr__(self) -> str:
-    """Return string representation of kaamiki's logger object."""
-    return f"Logger(root={self.root!r}, level={self.level!r})"
+    """Return the canonical string representation of kaamiki logger."""
+    return f"{self.__class__.__name__}(root={self.root!r})"
+
+  def critical(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log message with `CRITICAL` logging level."""
+    for line in str(msg).splitlines():
+      self.logger.critical(line, *args, **kwargs, stacklevel=2)
+
+  def error(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log message with `ERROR` logging level."""
+    for line in str(msg).splitlines():
+      self.logger.error(line, *args, **kwargs, stacklevel=2)
+
+  def warning(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log message with `WARNING` logging level."""
+    for line in str(msg).splitlines():
+      self.logger.warning(line, *args, **kwargs, stacklevel=2)
+
+  def info(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log message with `INFO` logging level."""
+    for line in str(msg).splitlines():
+      self.logger.info(line, *args, **kwargs, stacklevel=2)
+
+  def debug(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log message with `DEBUG` logging level."""
+    for line in str(msg).splitlines():
+      self.logger.debug(line, *args, **kwargs, stacklevel=2)
+
+  def exception(self, msg: Any, *args: Any, **kwargs: Any) -> None:
+    """Log exception with traceback."""
+    self.logger.error(msg, *args, **kwargs, exc_info=True, stacklevel=2)
+
+  fatal = critical
+  warn = warning


### PR DESCRIPTION
_Nov 14, 2020 - v0.0.1_

**Added:**
- Support for custom logging levels which enables the rendering of line
  breaks in the log messages. This also allows the use of `warn` and
  `fatal` logging levels.
- Support for enabling the original traceback and disable kaamiki's
  exception traceback format.
- Optional type hints to the optional arguments.
- List of original logging levels for validating user provided level.

**Changed:**
- User provided level is now validated while initializing Logger. If the
  levels are not correct then, errors are raised.
- \_\_repr\_\_ now returns just the root of the Logger.
- Code reorder and refactor.