### PR TITLE
Update default directory var and copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- 
-Copyright (c) 2020 Kaamiki Development Team. All rights reserved.
+Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,5 +22,5 @@ Author(s):
 
 ## License
 
-Copyright (c) 2020 Kaamiki Development Team. All rights reserved.<br>
+Copyright (c) 2021 Kaamiki Development Team. All rights reserved.<br>
 Licensed under the [Apache](https://github.com/kaamiki/kaamiki/blob/master/LICENSE) License 2.0

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,5 +1,5 @@
 <!-- 
-Copyright (c) 2020 Kaamiki Development Team. All rights reserved.
+Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kaamiki/config/settings.py
+++ b/kaamiki/config/settings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Kaamiki Development Team. All rights reserved.
+# Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,9 +79,9 @@ DEFAULT_ENCODING = 'utf-8'
 # Default seperator for strings and pathnames.
 DEFAULT_SEPERATOR = '_'
 
-# Default path for all framework related activities like logging, data
-# acquisition and caching. This directory can be overridden by the user
-# if needed.
-# NOTE(xames3): The implementation of overriding DEFAULT_BASE_DIR over
+# Default directory for all framework related activities like logging,
+# data acquisition and caching. This directory can be overridden by the
+# user if needed.
+# NOTE(xames3): The implementation of overriding DEFAULT_ROOT_DIR over
 #               user preference needs some serious thought.
-DEFAULT_BASE_DIR = MARK_ONE
+DEFAULT_ROOT_DIR = MARK_ONE


### PR DESCRIPTION
Jan 02, 2021 - v0.0.2

Changed:
- Default directory variable is now changed from `DEFAULT_BASE_DIR` to `DEFAULT_ROOT_DIR`.
- Copyright year is now changed to 2021 instead of 2020.