### PR TITLE
Merge module level changes from v0.0.2 to master

### DIFF
--- a/kaamiki/utils/exceptions.py
+++ b/kaamiki/utils/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Kaamiki Development Team. All rights reserved.
+# Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 # Author(s):
-#     xames3 <44119552+xames3@users.noreply.github.com>
+#           xames3 <xames3.kaamiki@gmail.com>
 
 """Collection of all the exceptions raised by Kaamiki framework."""
 
 from typing import Any
 
 
-class KaamikiBaseException(Exception):
+class KaamikiError(Exception):
     """Base exception class for all exceptions raised by Kaamiki."""
 
     msg = ''
@@ -58,3 +58,15 @@ class KaamikiBaseException(Exception):
             f'information or even a sample code for reproducing this bug '
             f'while\nsubmitting an issue.\n'
         )
+
+
+class UnexpectedTypeError(KaamikiError):
+    """Exception class to inherit for type checking based errors."""
+
+
+class FileSystemError(KaamikiError):
+    """Exception class to inherit for all filesystem based errors."""
+
+
+class InvalidDirectoryName(FileSystemError):
+    """Exception to be raised when the path has invalid components."""

--- a/kaamiki/utils/validations/types.py
+++ b/kaamiki/utils/validations/types.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author(s):
+#           xames3 <xames3.kaamiki@gmail.com>
+
+"""Module for validating objects based on their type."""
+
+from abc import ABC, abstractclassmethod
+from typing import Any
+
+
+class Contract(ABC):
+    """
+    Contract class for declaring constraints on the input data. If the
+    conditions aren't met, exceptions are raised.
+    """
+
+    @abstractclassmethod
+    def check(cls, value: Any) -> None:
+        pass


### PR DESCRIPTION
### Jan 03, 2021 - v0.0.2

**Added:**
- `kaamiki.utils.validations.types` module, this module is used for declaring constraints on the object based on their types.
- Exceptions for raising type and filesystem based errors.

**Changed:**
- **KaamikiBaseException** is now **KaamikiError**.
- Change year and author email in license boiler plate.