### PR TITLE
Merging validations module from v0.0.2 with master

### DIFF
--- a/kaamiki/utils/validations/__init__.py
+++ b/kaamiki/utils/validations/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Kaamiki Development Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author(s):
+#           xames3 <xames3.kaamiki@gmail.com>
+
+"""Unify all validations that propogate within Kaamiki."""
+
+from .filesystem import *
+from .types import *
+
+# pyright: reportUnsupportedDunderAll=false
+__all__ = (
+    filesystem.__all__
+    + types.__all__
+)


### PR DESCRIPTION
### Jan 05, 2021 - v0.0.2

**Added:**
- Exported objects from validation's sub-modules into validations (\_\_init\_\_.py).